### PR TITLE
Install APCu stable version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN usermod -G staff www-data
 COPY php.ini /usr/local/etc/php/conf.d/php.ini
 
 # Adding APCU for faster PHP
-RUN pecl install apcu-beta \
+RUN pecl install apcu \
     && echo extension=apcu.so > /usr/local/etc/php/conf.d/apcu.ini
 
 # https://www.drupal.org/drupal-7.41-release-notes


### PR DESCRIPTION
APCu is now shipped on two channels, beta and stable.

The beta version is for PHP 7, the stable version PHP 5.3+.
